### PR TITLE
add mbf_applr

### DIFF
--- a/arena_bringup/launch/start_arena.launch
+++ b/arena_bringup/launch/start_arena.launch
@@ -34,7 +34,7 @@
   <!-- ___________ ARGS ___________ -->
   <!-- You can launch a single robot and his local_planner with arguments -->
   <arg name="model" default="burger" doc="robot model type [burger, jackal, ridgeback, agvota, rto, ...]" />
-  <arg name="local_planner" default="teb" doc="local planner type [teb, dwa, mpc, rlca, arena, rosnav]" />
+  <arg name="local_planner" default="teb" doc="local planner type [teb, dwa, mpc, rlca, arena, rosnav, cohan, applr]" />
   <arg name="simulator" default="flatland" doc="[flatland, gazebo]" />
   <env name="SIMULATOR" value="$(arg simulator)" />
 

--- a/arena_bringup/launch/testing/move_base/mbf_applr.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_applr.launch
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <!-- Arguments -->
+  <arg name="model" default="jackal"/>
+  <arg name="speed" />
+  <arg name="move_forward_only" default="false"/>
+  <arg name="namespace" />
+  <arg name="frame" />
+  
+  <!-- move_base_flex -->
+  <group ns="move_base_flex">
+    <rosparam file="$(find arena_bringup)/params/mbf/applr_local_planner_params.yaml"
+      command="load" subst_value="True" />
+    <rosparam
+      file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/applr_local_planner_params.yaml"
+      command="load" subst_value="True" />
+
+    <param name="base_local_planner" value="TrajectoryPlannerROS"/>
+    <param name="base_global_planner" type="string" value="navfn/NavfnROS" />
+  </group>
+
+  <include file="$(find arena_bringup)/launch/testing/move_base/mbf_nav/costmap_nav.launch">
+    <arg name="model" value="$(arg model)" />
+    <arg name="speed" value="$(arg speed)" />
+    <arg name="namespace" value="$(arg namespace)" />
+    <arg name="frame" value="$(arg frame)" />
+  </include>
+
+
+  <node pkg="applr" type="test_param_policy.py" name="test_param_policy" output="screen"/>
+
+</launch>

--- a/arena_bringup/params/mbf/applr_local_planner_params.yaml
+++ b/arena_bringup/params/mbf/applr_local_planner_params.yaml
@@ -1,0 +1,13 @@
+controllers:
+  - name: TrajectoryPlannerROS
+    type: base_local_planner/TrajectoryPlannerROS
+
+controller_frequency: 5.0
+controller_patience: 15.0
+planner_frequency: 5.0
+max_planning_retries: 5.0
+
+TrajectoryPlannerROS:
+  odom_topic: odom
+  max_vel_x: $(arg speed)
+   


### PR DESCRIPTION
@voshch  added mbf-applr Planner

Simulation startet hier nun ebenfalls und der roboter erreicht das Ziel während er Hindernisse ausweicht.

Bekomme momentan noch in dem Terminal ein Error der die Simulation nicht verhindert:

**usage: test_param_policy.py [-h] [--world_id ID] [--policy_path POLICY_PATH]
                            [--default_dwa] [--verbose] [--gui]
                            [--repeats REPEATS]
test_param_policy.py: error: unrecognized arguments: /jackal/map:=/map __name:=test_param_policy __log:=/home/ahmo030/.ros/log/ba0f6e6c-84be-11ee-8604-af84a7378505/jackal-test_param_policy-8.log
[INFO] [1700166529.419466, 4.877000]: =============**

Der Error wird durch den Aufruf des skripts test_param_policy .py verursacht da er im launch file parameterübergabe erwartet. Im ursprünglichen launch file der noch nicht mit mbf implementiert war, waren ebenfalls keine Parameter übergeben und ich würde das morgen nochmal im Meeting abklären.  (Habe vorher applr planner zusätzlich installiert in dem sich dieses Skript befindet)

Githublink zur Installation: https://github.com/Daffan/nav-competition-icra2022/tree/applr





