### PR TITLE
add mbf-dragon

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -107,10 +107,10 @@
 #   local-name: ../planners/lflh
 #   uri: https://github.com/Arena-Rosnav/lflh
 #   version: master
-#- git:
-#   local-name: ../planners/dragon
-#   uri: https://github.com/Arena-Rosnav/dragon
-#   version: master
+- git:
+   local-name: ../planners/dragon
+   uri: https://github.com/Arena-Rosnav/dragon
+   version: master
 #- git:
 #   local-name: ../planners/trail
 #   uri: https://github.com/Arena-Rosnav/trail

--- a/arena_bringup/launch/start_arena.launch
+++ b/arena_bringup/launch/start_arena.launch
@@ -34,7 +34,7 @@
   <!-- ___________ ARGS ___________ -->
   <!-- You can launch a single robot and his local_planner with arguments -->
   <arg name="model" default="burger" doc="robot model type [burger, jackal, ridgeback, agvota, rto, ...]" />
-  <arg name="local_planner" default="teb" doc="local planner type [teb, dwa, mpc, rlca, arena, rosnav]" />
+  <arg name="local_planner" default="teb" doc="local planner type [teb, dwa, mpc, rlca, arena, rosnav, dragon]" />
   <arg name="simulator" default="flatland" doc="[flatland, gazebo]" />
   <env name="SIMULATOR" value="$(arg simulator)" />
 

--- a/arena_bringup/launch/testing/move_base/mbf_dragon.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_dragon.launch
@@ -6,25 +6,26 @@
   <arg name="move_forward_only" default="false"/>
   <arg name="namespace" />
   <arg name="frame" />
+  <arg name="odom_topic" default="odom" />
 
 
   <!-- move_base flex-->
   <group ns="move_base_flex">
-    <rosparam file="$(find arena_bringup)/params/mbf/dragon_local_planner_params.yaml"
-      command="load" subst_value="True" />
+    <!--<rosparam file="$(find arena_bringup)/params/mbf/dragon_local_planner_params.yaml"
+      command="load" subst_value="True" />-->
      <!--<rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/dragon_local_planner_params.yaml"
       command="load" subst_value="True" allow_none="true"/>-->
-    <param name="base_local_planner" value="DwaLocalPlannerROS" />
-    <param name="DwaLocalPlannerROS/min_vel_x" value="0.0" if="$(arg move_forward_only)" />  
   </group>
-
+  
   <!-- move_base flex costmap configs-->
+  
   <include file="$(find arena_bringup)/launch/testing/move_base/mbf_nav/costmap_nav.launch">
     <arg name="model" value="$(arg model)" />
     <arg name="speed" value="$(arg speed)" />
     <arg name="namespace" value="$(arg namespace)" />
     <arg name="frame" value="$(arg frame)" />
   </include>
+  
 
   <!-- Dragon Planner-->
   <node pkg="barn_challenge" type="gap_navigation" name="gap_navigation" output="screen">
@@ -43,5 +44,11 @@
     <param name="cap" value="10" />
   </node>
 
-  <node pkg="barn_challenge" type="cone_bench.py" name="cone_bench" output="screen" />
+  <node pkg="barn_challenge" type="cone_bench.py" name="cone_bench" output="screen">
+
+    <remap from="odom" to="$(arg odom_topic)"/>
+    <remap from="cmd_vel" to="cmd_vel"/>
+
+  </node>
+
 </launch>

--- a/arena_bringup/launch/testing/move_base/mbf_dragon.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_dragon.launch
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <!-- Arguments -->
+  <arg name="model" />
+  <arg name="speed" />
+  <arg name="move_forward_only" default="false"/>
+  <arg name="namespace" />
+  <arg name="frame" />
+
+
+  <!-- move_base flex-->
+  <group ns="move_base_flex">
+    <rosparam file="$(find arena_bringup)/params/mbf/dragon_local_planner_params.yaml"
+      command="load" subst_value="True" />
+     <!--<rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/dragon_local_planner_params.yaml"
+      command="load" subst_value="True" allow_none="true"/>-->
+    <param name="base_local_planner" value="DwaLocalPlannerROS" />
+    <param name="DwaLocalPlannerROS/min_vel_x" value="0.0" if="$(arg move_forward_only)" />  
+  </group>
+
+  <!-- move_base flex costmap configs-->
+  <include file="$(find arena_bringup)/launch/testing/move_base/mbf_nav/costmap_nav.launch">
+    <arg name="model" value="$(arg model)" />
+    <arg name="speed" value="$(arg speed)" />
+    <arg name="namespace" value="$(arg namespace)" />
+    <arg name="frame" value="$(arg frame)" />
+  </include>
+
+  <!-- Dragon Planner-->
+  <node pkg="barn_challenge" type="gap_navigation" name="gap_navigation" output="screen">
+    <param name="goal_x" value="10" />
+    <param name="goal_y" value="10" />
+    <param name="left" value="-100" />
+    <param name="top" value="-100" />
+    <param name="bwidth" value="200" />
+    <param name="bheight" value="200" />
+    <param name="gapThresh" value=".65" />
+    <param name="dist" value="10" />
+    <remap from="/scan" to="/truncate/scan" />
+  </node>
+
+  <node pkg="barn_challenge" type="reduce_lidar" name="reduce_lidar" output="screen">
+    <param name="cap" value="10" />
+  </node>
+
+  <node pkg="barn_challenge" type="cone_bench.py" name="cone_bench" output="screen" />
+</launch>

--- a/arena_bringup/params/mbf/dragon_local_planner_params.yaml
+++ b/arena_bringup/params/mbf/dragon_local_planner_params.yaml
@@ -1,0 +1,10 @@
+controllers:
+  - name: DwaLocalPlannerROS
+    type: dwa_local_planner/DWAPlannerROS
+
+controller_frequency: 5.0
+planner_frequency: 0.0
+
+DwaLocalPlannerROS:
+  - odom_topic: odom
+  - max_vel_x: $(arg speed)


### PR DESCRIPTION
@voshch 
**Nötigen Installationen:**
-Keine zusätzlichen installationen abgesehen von der rosinstall notwendig

**Veränderungen:**
-mbf launch file
-extra yaml file für den planner erstellt.

**Roboter zum starten der Simulation verwenden** : jackal

**Terminaleingabe:**
roslaunch arena_bringup start_arena.launch simulator:=gazebo task_mode:=scenario model:=jackal map_file:=map_empty local_planner:=dragon