### PR TITLE
add mbf-trail

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -111,10 +111,10 @@
 #   local-name: ../planners/dragon
 #   uri: https://github.com/Arena-Rosnav/dragon
 #   version: master
-#- git:
-#   local-name: ../planners/trail
-#   uri: https://github.com/Arena-Rosnav/trail
-#   version: master
+- git:
+   local-name: ../planners/trail
+   uri: https://github.com/Arena-Rosnav/trail
+   version: master
 #- git:
 #    local-name: ../planners/cohan
 #    uri: https://github.com/Arena-Rosnav/cohan_planner_multi

--- a/arena_bringup/launch/start_arena.launch
+++ b/arena_bringup/launch/start_arena.launch
@@ -34,7 +34,7 @@
   <!-- ___________ ARGS ___________ -->
   <!-- You can launch a single robot and his local_planner with arguments -->
   <arg name="model" default="burger" doc="robot model type [burger, jackal, ridgeback, agvota, rto, ...]" />
-  <arg name="local_planner" default="teb" doc="local planner type [teb, dwa, mpc, rlca, arena, rosnav]" />
+  <arg name="local_planner" default="teb" doc="local planner type [teb, dwa, mpc, rlca, arena, rosnav, trail]" />
   <arg name="simulator" default="flatland" doc="[flatland, gazebo]" />
   <env name="SIMULATOR" value="$(arg simulator)" />
 

--- a/arena_bringup/launch/testing/move_base/mbf_trail.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_trail.launch
@@ -14,6 +14,9 @@
     <rosparam file="$(find arena_bringup)/params/mbf/trail_local_planner_params.yaml"
       command="load" subst_value="True" />
 
+    <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/trail_local_planner_params.yaml"
+      command="load" subst_value="True" />
+
     <param name="base_local_planner" value="TrajectoryPlannerROS"/>
   </group>
    

--- a/arena_bringup/launch/testing/move_base/mbf_trail.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_trail.launch
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <!-- Arguments -->
+  <arg name="model" default="burger"/>
+  <arg name="speed" />
+  <arg name="namespace" default="" />
+  <arg name="frame" />
+  <arg name="move_forward_only" default="false"/>
+  <arg name="model_file"   default="$(find drl_vo_barn_nav)/src/model/drl_vo.zip"/>
+  
+
+  <!-- move_base_flex-->
+  <group ns="move_base_flex">
+    <rosparam file="$(find arena_bringup)/params/mbf/trail_local_planner_params.yaml"
+      command="load" subst_value="True" />
+
+    <param name="base_local_planner" value="TrajectoryPlannerROS"/>
+  </group>
+   
+   <include file="$(find arena_bringup)/launch/testing/move_base/mbf_nav/costmap_nav.launch">
+    <arg name="model" value="$(arg model)" />
+    <arg name="speed" value="$(arg speed)" />
+    <arg name="namespace" value="$(arg namespace)" />
+    <arg name="frame" value="$(arg frame)" />
+   </include>
+
+   <!-- Barn Data -->
+   <include file="$(find drl_vo_barn_nav)/launch/barn_data.launch"/>
+
+   <!-- DRL-VO Control Policy -->
+   <include file="$(find drl_vo_barn_nav)/launch/drl_vo_inference.launch">
+     <arg name="model_file" value="$(arg model_file)"/>
+     <arg name="start" value="true" />
+     <arg name="goal_x" value="0" />
+     <arg name="goal_y" value="0" />
+   </include>
+</launch>

--- a/arena_bringup/params/mbf/trail_local_planner_params.yaml
+++ b/arena_bringup/params/mbf/trail_local_planner_params.yaml
@@ -1,0 +1,10 @@
+controllers:
+  - name: TrajectoryPlannerROS
+    type: base_local_planner/TrajectoryPlannerROS
+
+controller_frequency: 5.0
+planner_frequency: 0.0
+
+TrajectoryPlannerROS:
+  odom_topic: odom
+  max_vel_x: $(arg speed)


### PR DESCRIPTION
@voshch
**wichtig**: poetry shell aktivieren wegen stable baselines 3

**Veränderungen:**
-mbf launch file
-extra yaml file für den planner erstellt.

**Roboter zum starten der Simulation verwenden** : jackal

**Terminaleingabe:**
roslaunch arena_bringup start_arena.launch simulator:=gazebo task_mode:=scenario model:=jackal map_file:=map_empty local_planner:=trail