### PR TITLE
add mbf_cadrl

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -71,10 +71,10 @@
     uri: https://github.com/Arena-Rosnav/arena-ros.git
     version: master
 
-#- git:
-#    local-name: ../planners/cadrl-ros
-#    uri: https://github.com/Arena-Rosnav/cadrl-ros.git
-#    version: master
+- git:
+    local-name: ../planners/cadrl-ros
+    uri: https://github.com/Arena-Rosnav/cadrl-ros.git
+    version: master
 
 #- git:
 #   local-name: ../planners/crowdnav-ros

--- a/arena_bringup/launch/start_arena.launch
+++ b/arena_bringup/launch/start_arena.launch
@@ -34,7 +34,7 @@
   <!-- ___________ ARGS ___________ -->
   <!-- You can launch a single robot and his local_planner with arguments -->
   <arg name="model" default="burger" doc="robot model type [burger, jackal, ridgeback, agvota, rto, ...]" />
-  <arg name="local_planner" default="teb" doc="local planner type [teb, dwa, mpc, rlca, arena, rosnav]" />
+  <arg name="local_planner" default="teb" doc="local planner type [teb, dwa, mpc, rlca, arena, rosnav, cadrl]" />
   <arg name="simulator" default="flatland" doc="[flatland, gazebo]" />
   <env name="SIMULATOR" value="$(arg simulator)" />
 

--- a/arena_bringup/launch/testing/move_base/mbf_cadrl.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_cadrl.launch
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+    <!-- move base -->
+    <arg name="model" />
+    <arg name="namespace" />
+    <arg name="frame" />
+    <arg name="speed" default="1.5"/>
+
+    <!-- move_base_flex_costmap-->
+    <include file="$(find arena_bringup)/launch/testing/move_base/mbf_nav/costmap_nav.launch">
+        <arg name="model" value="$(arg model)" />
+        <arg name="speed" value="$(arg speed)" />
+        <arg name="namespace" value="$(arg namespace)" />
+        <arg name="frame" value="$(arg frame)" />
+    </include>
+
+
+
+    
+    <arg name="file" default="cadrl_node_tb3.py"/>
+    <!-- Launch neural net ros wrapper -->
+    <node pkg="cadrl-ros" type="cadrl_node_tb3.py" name="cadrl_node" output="screen">
+
+        <!-- Publications -->
+        <remap from="~other_vels" to="other_vels"/>
+        <remap from="~nn_cmd_vel" to="cmd_vel"/>
+        <remap from="~pose_marker" to="pose_marker"/>
+        <remap from="~path_marker" to="path_marker"/>
+        <remap from="~goal_path_marker" to="goal_path_marker"/>
+        <remap from="~agent_marker" to="other_agents_marker"/>
+        <remap from="~agent_markers" to="other_agents_markers"/>
+
+        <!-- Subscriptions -->
+        <remap from="~pose" to="odom"/>
+        <remap from="~velocity" to="velocity"/>
+        <remap from="~safe_actions" to="local_path_finder/safe_actions"/>
+        <remap from="~planner_mode" to="planner_fsm/mode"/>
+        <remap from="~goal" to="move_base_simple/goal"/>
+        <remap from="~subgoal" to="subgoal"/>
+        <remap from="~clusters" to="/obst_odom"/>
+        <remap from="~peds" to="ped_manager/ped_recent"/>
+
+        <!-- Parameters -->
+        <param name="~speed" value="$(arg speed)"/>
+
+    </node>
+
+     <!-- spacial_horizon -->
+     <node pkg="spacial_horizon" type="spacial_horizon_node" name="spacial_horizon_node" output="screen">
+        <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/plan_fsm_param.yaml" command="load" />
+        <remap from="$(arg namespace)/goal" to="$(arg namespace)/move_base_simple/goal" />
+        <remap from="/move_base/NavfnROS/make_plan" to="$(arg namespace)/move_base_flex/NavfnROS/make_plan" />
+     </node>
+
+</launch>


### PR DESCRIPTION
@voshch
Installationsschritte: Schritte von der arena-rosnav website befolgt. Simulation läuft nur mit python3.6 welcher in virtueller umgebung verwendet wird.

Veränderungen:
-mbf launch file

Roboter zum starten der Simulation verwenden : jackal

Terminaleingabe:
roslaunch arena_bringup start_arena.launch simulator:=gazebo task_mode:=scenario model:=jackal map_file:=map_empty local_planner:=cadrl