### PR TITLE
add arena-mbf

### DIFF
--- a/arena_bringup/launch/testing/move_base/mbf_arena.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_arena.launch
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+    <!-- <arg name="speed" default="0.22"/> -->
+    <arg name="model" default="burger"/>
+    <arg name="speed" />
+    <arg name="namespace" />
+    <arg name="frame" />
+    <param name="bool_goal_reached" value="true" />
+
+    <!-- move_base -->
+    <remap from="move_base_flex/TebLocalPlannerROS/global_plan" to="/dev/null" /> 
+    <include file="$(find arena_bringup)/launch/testing/move_base/mbf_nav/costmap_nav.launch">
+      <arg name="model" value="$(arg model)" />
+      <arg name="speed" value="$(arg speed)" />
+      <arg name="namespace" value="$(arg namespace)" />
+      <arg name="frame" value="$(arg frame)" />
+    </include>
+
+
+
+    <!-- observation_packer -->
+    <node pkg="observations" name="observation_packer" type="observation_packer" output="screen"/>
+
+    <!-- Launch neural net ros wrapper -->
+    <node pkg="arena-ros" type="play_agent.py" name="arena_node" output="screen"/>
+    <!--<node pkg="arena-ros" type="arena_node_tb3.py" name="arena_node" output="screen" /> --> 
+    <!-- spacial_horizon -->
+    <node pkg="spacial_horizon" type="spacial_horizon_node" name="spacial_horizon_node" output="screen">
+        <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/plan_fsm_param.yaml" command="load" />
+        <remap from="$(arg namespace)/goal" to="$(arg namespace)/move_base_simple/goal" />
+        <remap from="/move_base/NavfnROS/make_plan" to="$(arg namespace)/move_base_flex/NavfnROS/make_plan" />
+    </node>
+
+
+    <group ns="move_base_flex">
+      <rosparam file="$(find arena_bringup)/params/mbf/teb_local_planner_params.yaml"
+        command="load" subst_value="True" />
+      <rosparam
+        file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/teb_local_planner_params.yaml"
+        command="load" subst_value="True" />
+
+      <param name="base_local_planner" value="TebLocalPlannerROS" />
+    </group>
+    
+    
+
+    
+</launch>

--- a/arena_bringup/launch/testing/move_base/mbf_arena.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_arena.launch
@@ -16,6 +16,18 @@
       <arg name="frame" value="$(arg frame)" />
     </include>
 
+    <group ns="move_base_flex">
+      <rosparam file="$(find arena_bringup)/params/mbf/arena_planner_params.yaml"
+        command="load" subst_value="True" />
+      <rosparam
+        file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/teb_local_planner_params.yaml"
+        command="load" subst_value="True" />
+
+      <param name="base_local_planner" value="TebLocalPlannerROS" />
+      <param name="base_global_planner" value="NavfnROS" />
+
+    </group>
+
 
 
     <!-- observation_packer -->
@@ -32,15 +44,6 @@
     </node>
 
 
-    <group ns="move_base_flex">
-      <rosparam file="$(find arena_bringup)/params/mbf/arena_planner_params.yaml"
-        command="load" subst_value="True" />
-      <rosparam
-        file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/teb_local_planner_params.yaml"
-        command="load" subst_value="True" />
-
-      <param name="base_local_planner" value="TebLocalPlannerROS" />
-    </group>
     
      
 </launch>

--- a/arena_bringup/launch/testing/move_base/mbf_arena.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_arena.launch
@@ -42,7 +42,5 @@
       <param name="base_local_planner" value="TebLocalPlannerROS" />
     </group>
     
-    
-
-    
+     
 </launch>

--- a/arena_bringup/launch/testing/move_base/mbf_arena.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_arena.launch
@@ -7,8 +7,31 @@
     <arg name="frame" />
     <param name="bool_goal_reached" value="true" />
 
-    <!-- move_base -->
-    <remap from="move_base_flex/TebLocalPlannerROS/global_plan" to="/dev/null" /> 
+   
+
+
+
+    <!-- observation_packer -->
+    <node pkg="observations" name="observation_packer" type="observation_packer" output="screen"/>
+
+    <!-- Launch neural net ros wrapper -->
+    <node pkg="arena-ros" type="play_agent.py" name="arena_node" output="screen"/>
+    <!--<node pkg="arena-ros" type="arena_node_tb3.py" name="arena_node" output="screen" /> --> 
+
+
+
+    
+    <!-- spacial_horizon -->
+    <node pkg="spacial_horizon" type="spacial_horizon_node" name="spacial_horizon_node" output="screen">
+        <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/plan_fsm_param.yaml" command="load" />
+        <remap from="$(arg namespace)/goal" to="$(arg namespace)/move_base_simple/goal" />
+        <remap from="/move_base/NavfnROS/make_plan" to="$(arg namespace)/move_base_flex/NavfnROS/make_plan" />
+    </node>
+
+
+ <!-- move_base -->
+    
+    <remap from="cmd_vel" to="/dev/null" /> <!-- optics -->
     <include file="$(find arena_bringup)/launch/testing/move_base/mbf_nav/costmap_nav.launch">
       <arg name="model" value="$(arg model)" />
       <arg name="speed" value="$(arg speed)" />
@@ -25,25 +48,8 @@
 
       <param name="base_local_planner" value="TebLocalPlannerROS" />
       <param name="base_global_planner" value="NavfnROS" />
+      
 
-    </group>
-
-
-
-    <!-- observation_packer -->
-    <node pkg="observations" name="observation_packer" type="observation_packer" output="screen"/>
-
-    <!-- Launch neural net ros wrapper -->
-    <node pkg="arena-ros" type="play_agent.py" name="arena_node" output="screen"/>
-    <!--<node pkg="arena-ros" type="arena_node_tb3.py" name="arena_node" output="screen" /> --> 
-    <!-- spacial_horizon -->
-    <node pkg="spacial_horizon" type="spacial_horizon_node" name="spacial_horizon_node" output="screen">
-        <rosparam file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/plan_fsm_param.yaml" command="load" />
-        <remap from="$(arg namespace)/goal" to="$(arg namespace)/move_base_simple/goal" />
-        <remap from="/move_base/NavfnROS/make_plan" to="$(arg namespace)/move_base_flex/NavfnROS/make_plan" />
-    </node>
-
-
-    
+    </group>   
      
 </launch>

--- a/arena_bringup/launch/testing/move_base/mbf_arena.launch
+++ b/arena_bringup/launch/testing/move_base/mbf_arena.launch
@@ -33,7 +33,7 @@
 
 
     <group ns="move_base_flex">
-      <rosparam file="$(find arena_bringup)/params/mbf/teb_local_planner_params.yaml"
+      <rosparam file="$(find arena_bringup)/params/mbf/arena_planner_params.yaml"
         command="load" subst_value="True" />
       <rosparam
         file="$(find arena-simulation-setup)/robot/$(arg model)/configs/mbf/teb_local_planner_params.yaml"

--- a/arena_bringup/params/mbf/arena_planner_params.yaml
+++ b/arena_bringup/params/mbf/arena_planner_params.yaml
@@ -1,0 +1,15 @@
+planners:
+  - name: NavfnROS
+    type: navfn/NavfnROS
+
+
+controllers:
+  - name: TebLocalPlannerROS
+    type: teb_local_planner/TebLocalPlannerROS
+
+TebLocalPlannerROS:
+  odom_topic: odom
+  max_vel_x: $(arg speed)
+
+
+planner_frequency: 0.0

--- a/arena_bringup/params/mbf/move_base_params.yaml
+++ b/arena_bringup/params/mbf/move_base_params.yaml
@@ -10,3 +10,6 @@ conservative_reset_dist: 3.0
 planner_frequency: 5.0
 oscillation_timeout: 10.0
 oscillation_distance: 0.2
+
+
+


### PR DESCRIPTION
@voshch
**Nötigen Installationen:**
-Keine zusätzlichen installationen abgesehen von der rosinstall notwendig

**Veränderungen:**
-mbf launch file

Roboter zum starten der Simulation verwenden : Burger

**Terminaleingabe:**
roslaunch arena_bringup start_arena.launch simulator:=gazebo task_mode:=scenario model:=Burger map_file:=map_empty local_planner:=arena

Beobachtungen: Alle Topics werden gepublished und ich erhalte keine Errors mehr. Jedoch werden keine linearen cmd vel gepublished nur rotatorische. Der Roboter dreht sich im Kreis. 