### PR TITLE
Hunavsim: Adding Obstacle Detection for Walls, Object , Robot, fixing Animation

### DIFF
--- a/arena.repos
+++ b/arena.repos
@@ -51,7 +51,7 @@ repositories:
   deps/hunav/hunav_sim:
     type: git
     url: https://github.com/voshch/hunav_sim.git
-    version: humble@1d4a486a
+    version: humble@025b9151
   deps/hunav/people_msgs:
     type: git
     url: https://github.com/wg-perception/people.git

--- a/arena_bringup/configs/hunav_agents/default.yaml
+++ b/arena_bringup/configs/hunav_agents/default.yaml
@@ -19,9 +19,9 @@ hunav_loader:
         vel: 0.6
         dist: 3.0
         goal_force_factor: 2.0
-        obstacle_force_factor: 30.0
-        social_force_factor: 5.0
-        other_force_factor: 20.0
+        obstacle_force_factor: 65.0
+        social_force_factor: 0.0
+        other_force_factor: 0.0
       init_pose:
         x: -3.973340
         y: -8.576801

--- a/arena_bringup/configs/hunav_agents/default.yaml
+++ b/arena_bringup/configs/hunav_agents/default.yaml
@@ -12,7 +12,7 @@ hunav_loader:
       max_vel: 5.0
       radius: 0.4
       behavior: 
-        type: 4  # REGULAR=1, IMPASSIVE=2, SURPRISED=3, SCARED=4, CURIOUS=5, THREATENING=6
+        type: 1  # REGULAR=1, IMPASSIVE=2, SURPRISED=3, SCARED=4, CURIOUS=5, THREATENING=6
         configuration: 0  # def: 0, custom:1, random_normal:2, random_uniform:3
         duration: 40.0  # seg
         once: true

--- a/hunav_gz_plugin/include/hunav_gz_plugin/HuNavSystemPlugin.h
+++ b/hunav_gz_plugin/include/hunav_gz_plugin/HuNavSystemPlugin.h
@@ -70,6 +70,7 @@
 #include "hunav_msgs/srv/compute_agents.hpp"
 #include "hunav_msgs/srv/get_agents.hpp"
 #include "hunav_msgs/srv/reset_agents.hpp"
+#include "hunav_msgs/srv/get_walls.hpp"
 //#include "hunav_msgs/srv/move_agent.hpp"
 
 #include <tf2/LinearMath/Matrix3x3.h>
@@ -128,6 +129,26 @@ private:
 
 
   void fixActorHeight(const hunav_msgs::msg::Agent& ag, gz::math::Pose3d& p);
+
+  //Wall struct and helper functions/variables
+  void loadWallData();
+  struct WallSegment {
+      int id;
+      gz::math::Vector3d start;
+      gz::math::Vector3d end;
+      double length;
+      double height;
+      gz::math::Vector3d center;
+      
+      WallSegment(int _id, const gz::math::Vector3d& _start, const gz::math::Vector3d& _end, 
+                  double _length, double _height)
+          : id(_id), start(_start), end(_end), length(_length), height(_height)
+          , center((_start + _end) / 2.0) {}
+  };
+
+  std::vector<WallSegment> cached_wall_segments_;
+  rclcpp::Client<hunav_msgs::srv::GetWalls>::SharedPtr wall_client_;
+  bool walls_loaded_;
 
   rclcpp::Node::SharedPtr rosnode_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr ros_test_pub_;

--- a/hunav_gz_plugin/include/hunav_gz_plugin/HuNavSystemPlugin.h
+++ b/hunav_gz_plugin/include/hunav_gz_plugin/HuNavSystemPlugin.h
@@ -115,8 +115,6 @@ public:
 
 private:
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
-  std::vector<geometry_msgs::msg::Point> wall_points_;
-  bool walls_initialized_ =false; 
   /// Helper functions
   void initializeAgents(gz::sim::EntityComponentManager& _ecm);
   void initializeRobot(gz::sim::EntityComponentManager& _ecm);

--- a/hunav_gz_plugin/src/HuNavSystemPlugin.cpp
+++ b/hunav_gz_plugin/src/HuNavSystemPlugin.cpp
@@ -620,9 +620,9 @@ void HuNavSystemPluginIGN::getObstacles(const gz::sim::EntityComponentManager& _
     double minDist = 5.0; //10000.0;
     //ignition::math::Vector3d closest_obstacle;
     // ignition::math::Vector3d closest_obs2;
-    //pedestrians_[p.first].closest_obs.clear();
+    pedestrians_[p.first].closest_obs.clear();
   
-    pedestrians_[p.first].closest_obs = wall_points_;  // No Clearing instead start with the walls as the base set of obstacles
+    //pedestrians_[p.first].closest_obs = wall_points_;  // No Clearing instead start with the walls as the base set of obstacles
     //RCLCPP_INFO(rosnode_->get_logger(), "Stored %zu wallpoints from agent", wall_points_.size());
 
     //gz::math::Pose3d actor_pose = worldPose(p.first, _ecm);

--- a/hunav_gz_plugin/src/HuNavSystemPlugin.cpp
+++ b/hunav_gz_plugin/src/HuNavSystemPlugin.cpp
@@ -764,11 +764,11 @@ if (walls_loaded_ && !cached_wall_segments_.empty())
       point.z = closest_point.Z();  // Keep Z coordinate like normal obstacles
       pedestrians_[p.first].closest_obs.push_back(point);
     
-      RCLCPP_WARN(this->rosnode_->get_logger(), 
-          "*** ADDED WALL OBSTACLE (%s): Actor[%.1f,%.1f,%.1f] -> Wall Point[%.1f,%.1f,%.1f], Distance=%.2f ***",
-          orientation_type.c_str(),
-          actor_pose.Pos().X(), actor_pose.Pos().Y(), actor_pose.Pos().Z(),
-          point.x, point.y, point.z, distance);
+      // RCLCPP_WARN(this->rosnode_->get_logger(), 
+      //     "*** ADDED WALL OBSTACLE (%s): Actor[%.1f,%.1f,%.1f] -> Wall Point[%.1f,%.1f,%.1f], Distance=%.2f ***",
+      //     orientation_type.c_str(),
+      //     actor_pose.Pos().X(), actor_pose.Pos().Y(), actor_pose.Pos().Z(),
+      //     point.x, point.y, point.z, distance);
         
       if(firstObstaclePrint_)
         RCLCPP_INFO(this->rosnode_->get_logger(), 

--- a/hunav_gz_plugin/src/HuNavSystemPlugin.cpp
+++ b/hunav_gz_plugin/src/HuNavSystemPlugin.cpp
@@ -338,13 +338,7 @@ void HuNavSystemPluginIGN::initializeAgents(gz::sim::EntityComponentManager& _ec
       //   continue;  // skip und beim nächsten Update wieder probieren
       // }
       
-      // Store the Wall Data which is coming from the Hunavmanager (store the already initialised closest_obstacles of the Peds from the manager into the variable, to have them still after every reset)
-      if (!agent.closest_obs.empty() && !walls_initialized_) {
-          
-          wall_points_ = agent.closest_obs;
-          walls_initialized_ = true;
-          //RCLCPP_INFO(rosnode_->get_logger(), "Stored %zu wallpoints from agent %s", wall_points_.size(), agent.name.c_str());
-      }
+ 
       // if(agent.closest_obs.empty()){
       //             RCLCPP_INFO(rosnode_->get_logger(), "CLOSEST OBSTACLES EMPTY !!!");
       // }
@@ -636,7 +630,7 @@ void HuNavSystemPluginIGN::getObstacles(const gz::sim::EntityComponentManager& _
     auto actor_pose = traj->Data();
 
     // we create a default bounding box for the actor
-    auto actor_size = gz::math::Vector3d(0.35, 0.35, 1.65); 
+    auto actor_size = gz::math::Vector3d(0.15, 0.15, 1.65); 
     gz::math::AxisAlignedBox actor_bb = gz::math::AxisAlignedBox(
       actor_pose.Pos() - actor_size / 2,
       actor_pose.Pos() + actor_size / 2
@@ -739,7 +733,7 @@ void HuNavSystemPluginIGN::getObstacles(const gz::sim::EntityComponentManager& _
         // if the entity has no geometry component, we can just use the center position
         // and we build a default small bounding box around it.  
         //ignmsg << "Entity " << obs_name->Data() << " has no Geometry component" << std::endl;
-        auto default_size = gz::math::Vector3d(0.35, 0.35, 1.0);
+        auto default_size = gz::math::Vector3d(0.30, 0.30, 1.0);
         gz::math::AxisAlignedBox obs_bb = gz::math::AxisAlignedBox(
           obs_pose.Pos() - default_size / 2,
           obs_pose.Pos() + default_size / 2

--- a/hunav_gz_plugin/src/HuNavSystemPlugin.cpp
+++ b/hunav_gz_plugin/src/HuNavSystemPlugin.cpp
@@ -343,8 +343,7 @@ void HuNavSystemPluginIGN::initializeAgents(gz::sim::EntityComponentManager& _ec
           
           wall_points_ = agent.closest_obs;
           walls_initialized_ = true;
-          RCLCPP_INFO(rosnode_->get_logger(), "Stored %zu wallpoints from agent %s", 
-                    wall_points_.size(), agent.name.c_str());
+          //RCLCPP_INFO(rosnode_->get_logger(), "Stored %zu wallpoints from agent %s", wall_points_.size(), agent.name.c_str());
       }
       // if(agent.closest_obs.empty()){
       //             RCLCPP_INFO(rosnode_->get_logger(), "CLOSEST OBSTACLES EMPTY !!!");
@@ -361,31 +360,31 @@ void HuNavSystemPluginIGN::initializeAgents(gz::sim::EntityComponentManager& _ec
       // get spawned in Gazebo with animations already and this part of the original Plugin Code interferes with the entity component manager!
       // When we change the usage of the plugin to a global way , this part of the code could be useful.  
 
-      // if (actorComp->Data().AnimationCount() < 1)
-      // {
-      //   gzerr << "Actor [" << actorComp->Data().Name()  << "] SDF doesn't have any animations." << std::endl;
-      //   return;
-      // }
-      // gzmsg << "Actor [" << actorComp->Data().Name()  << "] has " << actorComp->Data().AnimationCount() << " animations" << std::endl;
-      // // we take and apply the first animation!!!!
-      // auto ani = actorComp->Data().AnimationByIndex(0);
-      // gzmsg << "Animation name: " << ani->Name() << std::endl;
-      // gzmsg << "Animation filename: " << ani->Filename() << std::endl;
+      if (actorComp->Data().AnimationCount() < 1)
+      {
+        gzerr << "Actor [" << actorComp->Data().Name()  << "] SDF doesn't have any animations." << std::endl;
+        return;
+      }
+      gzmsg << "Actor [" << actorComp->Data().Name()  << "] has " << actorComp->Data().AnimationCount() << " animations" << std::endl;
+      // we take and apply the first animation!!!!
+      auto ani = actorComp->Data().AnimationByIndex(0);
+      gzmsg << "Animation name: " << ani->Name() << std::endl;
+      gzmsg << "Animation filename: " << ani->Filename() << std::endl;
 
-      // // Animation name
-      // auto animNameComp = _ecm.Component<gz::sim::components::AnimationName>(agentEntity);
-      // if(!animNameComp)
-      // {
-      //   gzwarn << "AnimationName component does not exist. Creating..." << std::endl;
-      //   _ecm.SetComponentData<gz::sim::components::AnimationName>(agentEntity, ani->Name().c_str()); //DEF_WALKING_ANIMATION); //ani->Name().c_str());
-      //   //_ecm.SetChanged(entity, gz::sim::components::AnimationName::typeId, gz::sim::ComponentState::OneTimeChange);
-      // }
-      // else
-      // {
-      //   *animNameComp = gz::sim::components::AnimationName(ani->Name().c_str()); //DEF_WALKING_ANIMATION); //ani->Name().c_str());
-      //   gzmsg << "Actor [" << actorComp->Data().Name()  << "] has animation name: " << animNameComp->Data() << std::endl;
-      // }
-      // _ecm.SetChanged(agentEntity, gz::sim::components::AnimationName::typeId, gz::sim::ComponentState::OneTimeChange);
+      // Animation name
+      auto animNameComp = _ecm.Component<gz::sim::components::AnimationName>(agentEntity);
+      if(!animNameComp)
+      {
+        gzwarn << "AnimationName component does not exist. Creating..." << std::endl;
+        _ecm.SetComponentData<gz::sim::components::AnimationName>(agentEntity, ani->Name().c_str()); //DEF_WALKING_ANIMATION); //ani->Name().c_str());
+        //_ecm.SetChanged(entity, gz::sim::components::AnimationName::typeId, gz::sim::ComponentState::OneTimeChange);
+      }
+      else
+      {
+        *animNameComp = gz::sim::components::AnimationName(ani->Name().c_str()); //DEF_WALKING_ANIMATION); //ani->Name().c_str());
+        gzmsg << "Actor [" << actorComp->Data().Name()  << "] has animation name: " << animNameComp->Data() << std::endl;
+      }
+      _ecm.SetChanged(agentEntity, gz::sim::components::AnimationName::typeId, gz::sim::ComponentState::OneTimeChange);
 
       // Animation time
       auto animTimeComp = _ecm.Component<gz::sim::components::AnimationTime>(agentEntity);
@@ -412,7 +411,7 @@ void HuNavSystemPluginIGN::initializeAgents(gz::sim::EntityComponentManager& _ec
       gz::math::Pose3d curr_pose;
       curr_pose.Pos().X(agent.position.position.x);
       curr_pose.Pos().Y(agent.position.position.y);
-      curr_pose.Pos().Z(0.35);
+      //curr_pose.Pos().Z(0.35);
       curr_pose.Rot() = gz::math::Quaterniond(0, 0, ag.yaw);
 
       // we try to give a name to the trajectory that matches the animation name
@@ -1247,7 +1246,7 @@ void HuNavSystemPluginIGN::updateGazeboPedestrians(gz::sim::EntityComponentManag
 
 
   // Update actor bone trajectories based on animation time
-  double animationFactor = 5.0; //0.005; //Noé
+  double animationFactor = 5; //0.005; //Noé
   auto animTimeComp = _ecm.Component<gz::sim::components::AnimationTime>(entity);
   if (!animTimeComp) {
       gzwarn << "Actor " << a.name << " does not have an AnimationTime component. Creating one..." << std::endl;

--- a/task_generator/task_generator/manager/entity_manager/hunav_manager/hunav_manager.py
+++ b/task_generator/task_generator/manager/entity_manager/hunav_manager/hunav_manager.py
@@ -165,6 +165,7 @@ class HunavManager(DummyEntityManager):
     SERVICE_MOVE_AGENT = 'move_agent'
     SERVICE_RESET_AGENTS = 'reset_agents'
     SERVICE_GET_AGENTS = 'get_agents'
+    SERVICE_GET_WALLS = 'get_walls' 
 
     def __init__(self, namespace: Namespace, simulator: BaseSimulator):
         """Initialize HunavManager with debug logging"""
@@ -210,7 +211,8 @@ class HunavManager(DummyEntityManager):
             'compute_agents': f'/{self.SERVICE_COMPUTE_AGENTS}',
             'move_agent': f'/{self.SERVICE_MOVE_AGENT}',
             'reset_agents': f'/{self.SERVICE_RESET_AGENTS}',
-            'get_agents': f'/{self.SERVICE_GET_AGENTS}'
+            'get_agents': f'/{self.SERVICE_GET_AGENTS}',
+            'get_walls': f'/{self.SERVICE_GET_WALLS}' 
         }
 
         # Log service creation attempts
@@ -249,6 +251,15 @@ class HunavManager(DummyEntityManager):
             self._get_agents_callback
         )
         self._logger.warn("GetAgents service provider created")
+
+        # Create GetWalls service provider
+        self._logger.warn(f"Creating get_walls service provider at: {service_names['get_walls']}")
+        self._get_walls_service = self.node.create_service(
+            GetWalls,
+            service_names['get_walls'],
+            self._get_walls_callback
+        )
+        self._logger.warn("GetWalls service provider created")
 
         # Wait for Services
         required_services = [

--- a/task_generator/task_generator/manager/entity_manager/hunav_manager/hunav_manager.py
+++ b/task_generator/task_generator/manager/entity_manager/hunav_manager/hunav_manager.py
@@ -132,16 +132,13 @@ class _PedestrianHelper:
                 <plugin name="HuNavSystemPluginIGN" filename="libHuNavSystemPluginIGN.so">
                     <update_rate>1000.0</update_rate>
                     <robot_name>jackal</robot_name>
-                    <use_gazebo_obs>false</use_gazebo_obs>
+                    <use_gazebo_obs>true</use_gazebo_obs>
                     <global_frame_to_publish>map</global_frame_to_publish>
                     <use_navgoal_to_start>false</use_navgoal_to_start>
                     <navgoal_topic>goal_pose</navgoal_topic>
                     <ignore_models>
                         <model>ground_plane</model>
                         <model>sun</model>
-                        <model>visual</model>
-                        <model>link</model>
-                        <model>collision</model>
                         <model>main_floor</model>
                         <model>surface</model>
                         <model>column</model>
@@ -405,7 +402,7 @@ class HunavManager(DummyEntityManager):
 
             # Add wall obstacles
             #self._logger.warn(f"Hunav Manager Wallpoints: {self._wall_points}")
-            agent_msg.closest_obs.extend(self._wall_points)
+            #agent_msg.closest_obs.extend(self._wall_points)
             #self._logger.warn(f"Hunav Manager Closest Obstacles: {agent_msg.closest_obs}")
 
             # After creating the agent message:


### PR DESCRIPTION
This Update consists of the following fixes:

Working obstacle detection realised through AABB :
-Every Ped has an AABB and for every Object (shelfs,boxes,robot) of the ecm an AABB is created
-Additionally created a new Message and Service in Hunavsim repo itself to get the Wall Segments. Callback and Service are realised in the Hunavmanager.py. For Each Wall Segment an AABB is created and the obstacle avoidance is realised in the same way as for the other Entities of the ECM.
(see hunavsim fork : https://github.com/voshch/hunav_sim/commits/humble/ ) 

Video of the realised obstacle avoidance for objects and walls : https://drive.google.com/drive/folders/16EtpppWqxLqDjKTo29Fzwh87xjkG8AQv (can be seen under the video name ,,Obstacle Avoidance Shelfs and Walls) 

Animation of the Pedestrians:
Animation Files are currenty switched to the provided .dae files of the Hunavsim Team. The .bvh files do not work also not for the repository maintainer of hunavsim since its an ungoing work. Therefore the .dae files are used which work perfectly fine for our current aim. The Animation Factor has an effect to the Pedestrians Movement. 
( https://github.com/robotics-upo/hunav_gazebo_fortress_wrapper/issues/1 ) 

Current Observations:
-Currently observing that every 10 or 12 second here and there the pedestrian lagg/teleport abrupty 2 or 3 meters. Trying to figure out why : My assumption is its a timing issue or its a more deeper error cause in the hunavagentmanager itself which needs more inspection. 
-We experienced weeks ago that the pedestrian spawn out of the map. For the launch with tm_obstacles:=scenario the pedestrians spawn in desired locations. For tm_obstacles:=random the pedestrians spawn out of the map.  
After looking up the issues board in the repo of hunavsim i realised another person had similar issues in which he describes that the pedestrians spawn out of the map: https://github.com/robotics-upo/hunav_gazebo_fortress_wrapper/issues/2 
This seems to be a deeper issue in the agentmanager or code of the hunavsim repo maintainer which i need to inspect further. But for some reason in the tm_obstacles:=scenario case the pedestrian spawn inside the map area. 


TO DO : 
- Finding root cause of above observations and fixxing them 
- Plugin works right now for Gazebo Garden. Implemenation in Hunavmanager for Isaac Sim will be done asap. 
- Currently Plugin is used for every Pedestrian. Next Step would be to load the Plugin dynamically into the map sdf to not load the Plugin all the time when creating the pedestrians in the loop. 

@voshch 

 
