### PR TITLE
Enable Pedestrian Hunav Reset to switch to different Scenarios

### DIFF
--- a/arena_bringup/configs/hunav_agents/default.yaml
+++ b/arena_bringup/configs/hunav_agents/default.yaml
@@ -9,7 +9,7 @@ hunav_loader:
       id: 1
       skin: 3
       group_id: -1
-      max_vel: 5.0
+      max_vel: 0.3
       radius: 0.4
       behavior: 
         type: 1  # REGULAR=1, IMPASSIVE=2, SURPRISED=3, SCARED=4, CURIOUS=5, THREATENING=6

--- a/task_generator/task_generator/manager/entity_manager/hunav_manager/hunav_manager.py
+++ b/task_generator/task_generator/manager/entity_manager/hunav_manager/hunav_manager.py
@@ -570,6 +570,36 @@ class HunavManager(DummyEntityManager):
         return True
 
     def _remove_obstacles_impl(self):
-        # self._wall_points = []
-        # TODO remove obstacles
+        """Remove all spawned pedestrians from simulation"""
+        self._logger.error(f"=== REMOVE_OBSTACLES_IMPL CALLED - REMOVING {len(self._pedestrians)} PEDESTRIANS ===")
+        self._logger.debug(f"=== REMOVING {len(self._pedestrians)} PEDESTRIANS ===")
+        
+        
+        self._logger.error(f"Pedestrians dict: {list(self._pedestrians.keys())}")
+        for ped_id, ped_data in self._pedestrians.items():
+            self._logger.error(f"Ped {ped_id}: {ped_data}")
+            obstacle = ped_data.get('obstacle')
+            if obstacle:
+                self._logger.debug(f"Removing pedestrian: {obstacle.name}")
+                self._simulator.remove_entity(obstacle.name)
+        
+        # Clear internal data structures
+        self._pedestrians.clear()
+        self._agents_container.agents.clear()
+        
+        if hasattr(self, '_update_timer') and self._update_timer:
+            self._update_timer.destroy()
+            self._update_timer = None
+        
+        # Reset hunav service
+        if self._reset_agents_client:
+            request = ResetAgents.Request()
+            try:
+                response = self._reset_agents_client.call(request)
+                if response:
+                    self._logger.debug("Successfully reset HuNav agents")
+            except Exception as e:
+                self._logger.error(f"Failed to reset HuNav agents: {e}")
+        
+        self._logger.debug("All pedestrians removed successfully")
         return True

--- a/task_generator/task_generator/manager/entity_manager/hunav_manager/hunav_manager.py
+++ b/task_generator/task_generator/manager/entity_manager/hunav_manager/hunav_manager.py
@@ -570,7 +570,7 @@ class HunavManager(DummyEntityManager):
         return True
 
     def _remove_obstacles_impl(self):
-        """Remove all spawned pedestrians from simulation"""
+        # """Remove all spawned pedestrians from simulation"""
         self._logger.error(f"=== REMOVE_OBSTACLES_IMPL CALLED - REMOVING {len(self._pedestrians)} PEDESTRIANS ===")
         self._logger.debug(f"=== REMOVING {len(self._pedestrians)} PEDESTRIANS ===")
         
@@ -581,7 +581,7 @@ class HunavManager(DummyEntityManager):
             obstacle = ped_data.get('obstacle')
             if obstacle:
                 self._logger.debug(f"Removing pedestrian: {obstacle.name}")
-                self._simulator.remove_entity(obstacle.name)
+                self._simulator.delete_entity(obstacle.name)
         
         # Clear internal data structures
         self._pedestrians.clear()
@@ -591,15 +591,15 @@ class HunavManager(DummyEntityManager):
             self._update_timer.destroy()
             self._update_timer = None
         
-        # Reset hunav service
-        if self._reset_agents_client:
-            request = ResetAgents.Request()
-            try:
-                response = self._reset_agents_client.call(request)
-                if response:
-                    self._logger.debug("Successfully reset HuNav agents")
-            except Exception as e:
-                self._logger.error(f"Failed to reset HuNav agents: {e}")
+        # # Reset hunav service
+        # if self._reset_agents_client:
+        #     request = ResetAgents.Request()
+        #     try:
+        #         response = self._reset_agents_client.call(request)
+        #         if response:
+        #             self._logger.debug("Successfully reset HuNav agents")
+        #     except Exception as e:
+        #         self._logger.error(f"Failed to reset HuNav agents: {e}")
         
-        self._logger.debug("All pedestrians removed successfully")
+        # self._logger.debug("All pedestrians removed successfully")
         return True


### PR DESCRIPTION
This PR contains following changes:

-Reset is enabled through : Delete_actor service callback (which deletes the pedestrians from the ECM after the Reset has been triggerd) and through ResetAgents which now deletes all registerd Actors from the Hunavsim System and emptys the behavior trees and enables the Agentmanager to register new Agents.
-The Simulation is started with only one Plugin being loaded with the first Actor (which acts as the Leader Agent). No multiple Plugins during simulation launch are loaded anymore.

Videos: https://drive.google.com/drive/folders/16EtpppWqxLqDjKTo29Fzwh87xjkG8AQv
(see Videos named ,,Scenario to Random" and ,,Random to Scenario")

Important Repos:

Hunavsim commits:
https://github.com/AhmedMartban/hunav_sim/commits/humble/

Hunavgz_plugin commits:
https://github.com/AhmedMartban/hunav_gz_plugin/commits/main/

Hunavmanager commits (arena-rosnav)
https://github.com/AhmedMartban/arena-rosnav/commits/dev_error/

Current Observations:
-Rviz Gazebo Position inconsistencies regarding tm_obstacles:=random
-Reset from Scenario to Scenario or Random to Scenario is no Problem, but from Scenario to Random results in a Scenario Reset.

@voshch